### PR TITLE
Fix failing test case

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /login/i });
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update `App.test.js` to check for Login heading instead of React template placeholder

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3ac05d348327b4c11c0bf2096b99